### PR TITLE
Remove requirement for role_arn

### DIFF
--- a/dedunu/provider.go
+++ b/dedunu/provider.go
@@ -34,7 +34,7 @@ func Provider() terraform.ResourceProvider {
 			},
 			"role_arn": {
 				Type:     schema.TypeString,
-				Required: true,
+				Required: false,
 				Description: "Amazon Resource Name of an IAM Role to assume prior to making\n" +
 					"the AWS Lambda call.",
 				InputDefault: "",


### PR DESCRIPTION
Attribute role_arn is not a required input for the AWS provider this module is based on. We will stop supporting assume_role for AWS authentication in the near future and only use profile based authentication.