### PR TITLE
Either required or optional is required

### DIFF
--- a/dedunu/provider.go
+++ b/dedunu/provider.go
@@ -34,7 +34,7 @@ func Provider() terraform.ResourceProvider {
 			},
 			"role_arn": {
 				Type:     schema.TypeString,
-				Required: false,
+				Optional: true,
 				Description: "Amazon Resource Name of an IAM Role to assume prior to making\n" +
 					"the AWS Lambda call.",
 				InputDefault: "",


### PR DESCRIPTION
```
│ Error: Internal validation of the provider failed! This is always a bug
│ with the provider itself, and not a user issue. Please report
│ this bug:
│
│ 1 error occurred:
│ 	* role_arn: One of optional, required, or computed must be set
```